### PR TITLE
Add fallback to USB camera when Pi camera fails

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -161,7 +161,7 @@ function showCameraError() {
     document.getElementById('videoContainer').innerHTML = 
         '<div class="alert alert-warning m-3">' +
         '<i class="fas fa-exclamation-triangle me-2"></i>' +
-        'Impossible d\'accéder à la caméra. Vérifiez que libcamera est installé et que la caméra est connectée.' +
+        'Impossible d\'accéder à la caméra. Vérifiez que les dépendances nécessaires sont installées et que la caméra est connectée.' +
         '</div>';
 }
 


### PR DESCRIPTION
## Summary
- add automatic USB camera fallback when Pi camera initialization fails
- clarify front-end error message about missing camera dependencies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baeea3472c832aaff84faff9e7b7d3