### PR TITLE
Install Picamera2 dependencies for Raspberry Pi camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Un script `setup.sh` est fourni pour automatiser l'ensemble du processus sur un 
     ```
     Ce script s'occupe de :
     - Mettre à jour les paquets système.
-    - Installer les dépendances système (`libcamera-apps`, `python3-opencv`).
+    - Installer les dépendances système (`libcamera-apps`, `python3-opencv`, `python3-picamera2`).
     - Créer un environnement virtuel `venv`.
     - Installer les dépendances Python de `requirements.txt` dans cet environnement.
     - Creer un mode kiosk automatique au demarrage du systeme.
@@ -98,7 +98,7 @@ Suivez ces étapes pour une installation manuelle.
     ```bash
     sudo apt update
     sudo apt upgrade
-    sudo apt install libcamera-apps python3-opencv
+    sudo apt install libcamera-apps python3-opencv python3-picamera2
     ```
 
 3.  **Installer les dépendances Python :**

--- a/setup.sh
+++ b/setup.sh
@@ -193,7 +193,12 @@ update_system() {
 }
 
 install_dependencies() {
-  local pkgs=(python3 python3-venv python3-pip build-essential libcap2-bin libcap-dev xserver-xorg xinit x11-xserver-utils unclutter)
+  local pkgs=(
+    python3 python3-venv python3-pip
+    build-essential libcap2-bin libcap-dev
+    xserver-xorg xinit x11-xserver-utils unclutter
+    libcamera-apps python3-opencv python3-picamera2
+  )
   [[ -n "$CHROMIUM_PKG" ]] && pkgs+=("$CHROMIUM_PKG")
   step "Installation des dépendances"
   log "${#pkgs[@]} paquets à installer"


### PR DESCRIPTION
## Summary
- Install `libcamera-apps`, `python3-opencv`, and `python3-picamera2` during setup
- Document Picamera2 dependency in README installation instructions

## Testing
- `bash -n setup.sh`
- `python -m py_compile camera_utils.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bafca5334c832a96ee5822f37bbd1d