### PR TITLE
Improve Raspberry Pi camera support with libcamera

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ L'application supporte deux types de caméras, configurables depuis la page d'ad
 
 ### Pi Camera (par défaut)
 
-- Utilise le module `libcamera-vid` pour capturer le flux vidéo
+- Utilise la bibliothèque **Picamera2** pour le flux vidéo
+- Capture les photos en pleine résolution via `libcamera-still` lorsque disponible
 - Idéal pour les Raspberry Pi avec caméra officielle
 - Aucune configuration supplémentaire requise
 


### PR DESCRIPTION
## Summary
- use V4L2 backend in PiCameraStream fallback
- use libcamera-still when available for high-res captures
- document Picamera2 and libcamera-still usage in README

## Testing
- `python -m py_compile camera_pi.py`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbfe1148dc832aab3073d0c6df744e